### PR TITLE
sending response back to client

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.post('/chat', (req, res) => {
   const { message } = req.body;
   processMessage(message);
+  res.send();
 });
 
 app.set('port', process.env.PORT || 5000);


### PR DESCRIPTION
sending response back to client to prevent auto-resubmitting after 2 minute timeout.  This fixes the bugs with message limit and message randomly resubmitting.